### PR TITLE
Add ignoreMaxItems option.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,12 @@ export interface Options {
    */
   ignoreMinAndMaxItems: boolean
   /**
+   * Ignore maxItems for `array` types.
+   *
+   * Retains the benefit of minItems, commonly used to enforce non-empty arrays, without the risk of generating massive tuple unions for large values of maxItems.
+   */
+  ignoreMaxItems: boolean
+  /**
    * Append all index signatures with `| undefined` so that they are strictly typed.
    *
    * This is required to be compatible with `strictNullChecks`.
@@ -82,6 +88,7 @@ export const DEFAULT_OPTIONS: Options = {
   enableEnumTypes: false,
   format: true,
   ignoreMinAndMaxItems: false,
+  ignoreMaxItems: false,
   strictIndexSignatures: false,
   style: {
     bracketSpacing: false,

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -63,10 +63,12 @@ rules.set('Escape closing JSDoc Comment', schema => {
 })
 
 rules.set('Optionally remove maxItems and minItems', (schema, _rootSchema, _fileName, options) => {
-  if (options.ignoreMinAndMaxItems) {
+  if (options.ignoreMinAndMaxItems || options.ignoreMaxItems) {
     if ('maxItems' in schema) {
       delete schema.maxItems
     }
+  }
+  if (options.ignoreMinAndMaxItems) {
     if ('minItems' in schema) {
       delete schema.minItems
     }


### PR DESCRIPTION
Respecting `maxItems` can cause an explosion in tuple unions for large values. We previously had the option of ignoring both `minItems` and `maxItems`, but this loses the benefit of enforcing non-empty arrays conferred by `minItems`. `minItems` is generally safer because it tends to have low values.

Retains the existing `ignoreMinAndMaxItems` for backwards compatibility.

Doesn't add a test because the existing ones appear to be broken (modulo some environment setup problem I have).